### PR TITLE
Skipmissing before starting the inner loop

### DIFF
--- a/src/rqatrend.jl
+++ b/src/rqatrend.jl
@@ -49,7 +49,7 @@ Compute the RQA trend metric for the non-missing time steps of xin, and save it 
 `thresh` specifies the epsilon threshold of the Recurrence Plot computation
 """
 function rqatrend(pix_trend, pix, thresh=2)
-    pix_trend .= rqatrend_impl(pix; thresh)
+    pix_trend .= rqatrend_impl(collect(skipmissing(pix)); thresh)
 end
 
 


### PR DESCRIPTION
Until we fixed the data loading so that the different scenes are already merged we should do a skipmissing before applying the inner loop.
This can be removed, once the data loading is fixed. 