### PR TITLE
Update API dates use timespan

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -2,6 +2,9 @@ using ArgParse
 using YAXArrays: YAXDefaults
 
 const argparsesettings = ArgParseSettings()
+
+ArgParse.parse_item(::Type{Date}, x::AbstractString) = Date(x)
+
 @add_arg_table! argparsesettings begin
     "--threshold", "-t"
     help = "Threshold for the recurrence matrix computation"

--- a/src/main.jl
+++ b/src/main.jl
@@ -13,11 +13,15 @@ const argparsesettings = ArgParseSettings()
 
     "--start-date"
     help = "Start date of the time series to analyze in ISO 8601 format YYYY-MM-DD"
-    arg_type = String
+    required = true
+    arg_type = Date
+    dest_name = "start_date"
 
     "--end-date"
     help = "End date of the time series to analyze in ISO 8601 format YYYY-MM-DD"
-    arg_type = String
+    required = true
+    arg_type = Date
+    dest_name = "end_date"
 
     "--orbit", "-o"
     help = "One of: Orbit number, 'A' for ascending, 'D' for descending, '*' for all orbits"

--- a/src/main.jl
+++ b/src/main.jl
@@ -85,6 +85,11 @@ function main(;
         mkdir(outdir)
         @info "Write output to $outdir"
     end
+
+    if end_date - start_date < Dates.Day(365)
+        @warn "Selected time series is less than a year. This will introduce seasonal bias."
+    end
+
     YAXDefaults.workdir[] = outdir
 
     corruptedfiles = "corrupted_tiles.txt"

--- a/src/main.jl
+++ b/src/main.jl
@@ -86,7 +86,7 @@ function main(;
         @info "Write output to $outdir"
     end
 
-    if Dates.Day(start_date) != Dates.Day(end_date) || Dates.Month(start_date) != Dates.Month(end_date)
+    if monthday(start_date) != monthday(end_date)
         @warn "Selected time series does not include a multiple of whole years. This might introduce seasonal bias."
     end
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -86,8 +86,8 @@ function main(;
         @info "Write output to $outdir"
     end
 
-    if end_date - start_date < Dates.Day(365)
-        @warn "Selected time series is less than a year. This will introduce seasonal bias."
+    if Dates.Day(start_date) != Dates.Day(end_date) || Dates.Month(start_date) != Dates.Month(end_date)
+        @warn "Selected time series does not include a multiple of whole years. This might introduce seasonal bias."
     end
 
     YAXDefaults.workdir[] = outdir

--- a/src/main.jl
+++ b/src/main.jl
@@ -11,12 +11,13 @@ const argparsesettings = ArgParseSettings()
     help = "Polarisation that should be stacked"
     default = "VH"
 
-    "--years", "--year", "-y"
-    help = "Year in which the RQA Trend should be detected. 
-    We take a buffer of six month before and after the year to end up with two years of data."
-    default = [2018, 2019, 2020, 2021, 2022, 2023]
-    nargs = '+'
-    arg_type = Int
+    "--start-date"
+    help = "Start date of the time series to analyze in ISO 8601 format YYYY-MM-DD"
+    arg_type = String
+
+    "--end-date"
+    help = "End date of the time series to analyze in ISO 8601 format YYYY-MM-DD"
+    arg_type = String
 
     "--orbit", "-o"
     help = "One of: Orbit number, 'A' for ascending, 'D' for descending, '*' for all orbits"
@@ -58,13 +59,14 @@ end
 
 function main(;
     tiles::Vector{String},
-    continent::String, 
+    continent::String,
     indir::String,
     outdir="out.zarr",
-    years=[2018, 2019, 2020, 2021, 2022, 2023],
-    polarisation="VH", 
-    orbit="*", 
-    threshold=3.0, 
+    start_date::Date,
+    end_date::Date,
+    polarisation="VH",
+    orbit="*",
+    threshold=3.0,
     folders=["V01R01", "V0M2R4", "V1M0R1", "V1M1R1", "V1M1R2"]
 )
     if isdir(indir) && isempty(indir)
@@ -89,42 +91,39 @@ function main(;
         relorbits = unique([split(basename(x), "_")[5][2:end] for x in allfilenames])
         @show relorbits
         for relorbit in relorbits
-            for y in years
+            filenames = allfilenames[findall(contains("$(relorbit)_E"), allfilenames)]
+            @time cube = gdalcube(filenames)
 
-                filenames = allfilenames[findall(contains("$(relorbit)_E"), allfilenames)]
-                @time cube = gdalcube(filenames)
+            path = joinpath(YAXDefaults.workdir[], "$(tilefolder)_rqatrend_$(polarisation)_$(relorbit)_thresh_$(threshold)")
+            @show path
+            ispath(path * ".done") && continue
+            ispath(path * "_zerotimesteps.done") && continue
 
-                path = joinpath(YAXDefaults.workdir[], "$(tilefolder)_rqatrend_$(polarisation)_$(relorbit)_thresh_$(threshold)_year_$(y)")
-                @show path
-                ispath(path * ".done") && continue
-                ispath(path * "_zerotimesteps.done") && continue
-
-                tcube = cube[Time=Date(y - 1, 7, 1) .. Date(y + 1, 7, 1)]
-                @show size(cube)
-                @show size(tcube)
-                if size(tcube, 3) == 0
-                    touch(path * "_zerotimesteps.done")
-                    continue
-                end
-                try
-                    @time rqatrend(tcube; thresh=threshold, outpath=path * ".zarr", overwrite=true)
-                catch e
-
-                    if hasproperty(e, :captured) && e.captured.ex isa ArchGDAL.GDAL.GDALError
-                        println("Found GDALError:")
-                        println(e.captured.ex.msg)
-                        continue
-                    else
-                        rethrow(e)
-                    end
-                end
-                #=@everywhere begin
-                    fname = "$(VERSION)_$(getpid())_$(time_ns()).heapsnapshot"
-                    Profile.take_heap_snapshot(fname;streaming=true)
-                end
-                =#
-                touch(path * ".done")
+            tcube = cube[Time=start_date .. end_date]
+            @show size(cube)
+            @show size(tcube)
+            if size(tcube, 3) == 0
+                touch(path * "_zerotimesteps.done")
+                continue
             end
+            try
+                @time rqatrend(tcube; thresh=threshold, outpath=path * ".zarr", overwrite=true)
+            catch e
+
+                if hasproperty(e, :captured) && e.captured.ex isa ArchGDAL.GDAL.GDALError
+                    println("Found GDALError:")
+                    println(e.captured.ex.msg)
+                    continue
+                else
+                    rethrow(e)
+                end
+            end
+            #=@everywhere begin
+                fname = "$(VERSION)_$(getpid())_$(time_ns()).heapsnapshot"
+                Profile.take_heap_snapshot(fname;streaming=true)
+            end
+            =#
+            touch(path * ".done")
         end
     end
 end

--- a/test/testdata.jl
+++ b/test/testdata.jl
@@ -5,7 +5,7 @@
     ensure_artifact_installed("rqatestdata", "Artifacts.toml")
     testdatapath = joinpath(artifact"rqatestdata", "RQADeforestationTestData-2.0")
 
-    testdir = "tmp/testdata" 
+    testdir = "tmp/testdata"
     rm(testdir, recursive=true, force=true)
     mkpath(testdir)
     outdir = "$testdir/out.zarr"
@@ -16,6 +16,8 @@
     copy!(ARGS, [
         "--tile", "E051N018T3",
         "--continent", "EU",
+        "--start-date", "2021-01-01",
+        "--end-date", "2021-12-31",
         "--in-dir", indir,
         "--out-dir", outdir,
     ])


### PR DESCRIPTION
This PR aims to clarify the CLI API and fix #78 . Previously, `rqatrend` was called for each year of a list `years` by implicitly adding half a year of buffer. Now, the time span to be analysed is given explicitly using arguments `start_date` and `end_date` of the `main` function. This allows for any arbitrary input time spans. Furthermore, this helps us in returning just one zarr array per call.