### PR TITLE
Consolidate zarr metadata to allow open from object store and web

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -121,7 +121,9 @@ function main(;
                 continue
             end
             try
-                @time rqatrend(tcube; thresh=threshold, outpath=path * ".zarr", overwrite=true)
+                outpath = path * ".zarr"
+                @time rqatrend(tcube; thresh=threshold, outpath=outpath, overwrite=true)
+                Zarr.consolidate_metadata(outpath)
             catch e
 
                 if hasproperty(e, :captured) && e.captured.ex isa ArchGDAL.GDAL.GDALError


### PR DESCRIPTION
This PR aims to enable to open the output zarr dataset from object stores and the web.
Hereby, zarr metadata needs to be consolidated.