### PR TITLE
Add unit test for meanvote and postprocess

### DIFF
--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -6,7 +6,7 @@ using Statistics
 using FillArrays
 #maskfolder = "data/forestcompressed"
 
-function meanvote(orbits, significance_thresh=-1.28)
+function meanvote(orbits, significance_thresh=50)
     s, n = 0.0, 0
     for i in eachindex(orbits)
         if orbits[i] != 0 && !isnan(orbits[i])
@@ -15,9 +15,18 @@ function meanvote(orbits, significance_thresh=-1.28)
         end
     end
     m = s / n
-    return m < significance_thresh ? 1 : 0
+    return m > significance_thresh ? 1 : 0
 end
 
+@testitem "meanvote" begin
+    using RQADeforestation: meanvote
+    orbits = [20,40,200, NaN]
+    mv = meanvote(orbits)
+    @test mv == 1
+    orbits2 = [60,60,50]
+    @test meanvote(orbits2) == 1
+    @test meanvote([40,40,NaN]) == 0
+end
 function filtersmallcomps!(
     xout, xin_unfiltered, forestmask, comborbits, connsize; dims=:, threaded=false
 )

--- a/src/rqatrend.jl
+++ b/src/rqatrend.jl
@@ -8,8 +8,8 @@ using Distances
 Compute the RQA trend metric for the datacube `cube` with the epsilon threshold `thresh`.
 `lowerbound` and `upperbound` are forwarded to the classification of the RQA Trend result.
 """
-function rqatrend(cube; thresh=2, lowerbound=-5, upperbound=-0.5, outpath=tempname() * ".zarr", overwrite=false, kwargs...)
-    mapCube(rqatrend, cube, thresh, lowerbound, upperbound; indims=InDims("Time"), outdims=OutDims(; outtype=UInt8, path=outpath, fill_value=255, overwrite, kwargs...))
+function rqatrend(cube; thresh=2, lowerbound=-5, upperbound=-0.5, outpath=tempname() * ".zarr", overwrite=false, classify=true, kwargs...)
+    mapCube(rqatrend, cube, thresh, lowerbound, upperbound; classify, indims=InDims("Time"), outdims=OutDims(; outtype=UInt8, path=outpath, fill_value=255, overwrite, kwargs...))
 end
 
 @testitem "rqatrend cube" begin
@@ -52,8 +52,13 @@ Compute the RQA trend metric for the non-missing time steps of xin, and save it 
 `lowerbound` and `upperbound` are the bounds of the classification into UInt8.
 The result of rqatrend are UInt8 values between 0 (no change) to 254 (definitive change) with 255 as sentinel value for missing data.
 """
-function rqatrend(pix_trend, pix, thresh=2, lowerbound=-5., upperbound=-0.5)
-    pix_trend .= classify_rqatrend(rqatrend_impl(pix; thresh); lowerbound, upperbound)
+function rqatrend(pix_trend, pix, thresh=2, lowerbound=-5., upperbound=-0.5; classify=true)
+    rqaval = rqatrend_impl(pix; thresh)
+    if classify
+        pix_trend .= classify_rqatrend(rqaval; lowerbound, upperbound)
+    else
+        pix_trend .= rqaval
+    end
 end
 
 """

--- a/test/testdata.jl
+++ b/test/testdata.jl
@@ -29,6 +29,13 @@
     @test size(a) == (50, 74)
     @test minimum(a) == 0 
     @test maximum(a) > 200
+
+    rqain = cat(a,a, dims=Dim{:Orbits}([1,2]))
+    clustered = similar(a)
+    RQADeforestation.postprocess(rqain, clustered, a .> 0)
+    @test size(clustered) == (50, 74)
+    @test unique(clustered) == [0,1]
+    @test clustered[end,end] == 1
 end
 
 @testitem "testdata julia_main" begin


### PR DESCRIPTION
This adds unit tests for meanvote and post process via the example data. 
This also changes the default threshold to reflect the classification.

I also added a classify keyword to rqatrend so that we can run the raw rqatrend without the classifcation. This was mainly used to understand and verify whether the classify is working as expected. 